### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/goss_tests.yml
+++ b/.github/workflows/goss_tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Run goss tests
         run: GOSS_PATH="$HOME/bin/goss" $HOME/bin/dgoss run -t luotaoruby/jenkins-ssh-ruby-rails-web-slave
       - name: Publish to dockerhub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: luotaoruby/jenkins-ssh-ruby-rails-web-slave
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore